### PR TITLE
refactored round state

### DIFF
--- a/Scarb.toml
+++ b/Scarb.toml
@@ -17,5 +17,5 @@ dojo = { git = "https://github.com/dojoengine/dojo", tag = "v1.2.2" }
 build-external-contracts = ["dojo::world::world_contract::world"]
 
 [dev-dependencies]
-cairo_test = "=2.9.2"
+cairo_test = "2.9.2"
 dojo_cairo_test = { git = "https://github.com/dojoengine/dojo", tag = "v1.2.2" }

--- a/src/lib.cairo
+++ b/src/lib.cairo
@@ -1,10 +1,9 @@
-pub mod systems;
-
 pub mod models;
+pub mod systems;
 
 pub mod tests {
     mod test_world;
 }
+pub mod alias;
 
 pub mod constants;
-pub mod alias;

--- a/src/models.cairo
+++ b/src/models.cairo
@@ -1,3 +1,3 @@
+pub mod card;
 pub mod config;
 pub mod round;
-pub mod card;

--- a/src/models/round.cairo
+++ b/src/models/round.cairo
@@ -1,4 +1,4 @@
-use starknet::{ContractAddress};
+use starknet::ContractAddress;
 
 #[derive(Copy, Drop, Serde, Debug)]
 #[dojo::model]

--- a/src/models/round.cairo
+++ b/src/models/round.cairo
@@ -16,14 +16,20 @@ pub struct Rounds {
     pub round: Round,
 }
 
+#[derive(Copy, Drop, Serde, Debug)]
+pub enum RoundState {
+    Pending,
+    Started,
+    Completed,
+}
+
 #[derive(Copy, Drop, Serde, IntrospectPacked, Debug)]
 pub struct Round {
     pub creator: ContractAddress,
     pub genre: felt252,
     pub wager_amount: u256,
     pub start_time: u64,
-    pub is_started: bool,
-    pub is_completed: bool,
+    pub state: RoundState,
     pub end_time: u64,
     pub next_card_index: u8,
     pub players_count: u256,

--- a/src/models/round.cairo
+++ b/src/models/round.cairo
@@ -16,7 +16,7 @@ pub struct Rounds {
     pub round: Round,
 }
 
-#[derive(Copy, Drop, Serde, Debug)]
+#[derive(Copy, Drop, Serde, Introspect, Debug)]
 pub enum RoundState {
     Pending,
     Started,

--- a/src/models/round.cairo
+++ b/src/models/round.cairo
@@ -1,4 +1,4 @@
-use starknet::ContractAddress;
+use starknet::{ContractAddress};
 
 #[derive(Copy, Drop, Serde, Debug)]
 #[dojo::model]
@@ -29,8 +29,33 @@ pub struct Round {
     pub genre: felt252,
     pub wager_amount: u256,
     pub start_time: u64,
-    pub state: RoundState,
+    pub state: felt252,
     pub end_time: u64,
     pub next_card_index: u8,
     pub players_count: u256,
 }
+
+impl RoundStateIntoFelt252 of Into<RoundState, felt252> {
+    fn into(self: RoundState) -> felt252 {
+        match self {
+            RoundState::Pending => 'PENDING',
+            RoundState::Started => 'STARTED',
+            RoundState::Completed => 'COMPLETED',
+        }
+    }
+}
+
+impl Felt252TryIntoRoundState of TryInto<felt252, RoundState> {
+    fn try_into(self: felt252) -> Option<RoundState> {
+        if self == 'PENDING' {
+            Option::Some(RoundState::Pending)
+        } else if self == 'STARTED' {
+            Option::Some(RoundState::Started)
+        } else if self == 'COMPLETED' {
+            Option::Some(RoundState::Completed)
+        } else {
+            Option::None
+        }
+    }
+}
+

--- a/src/systems/actions.cairo
+++ b/src/systems/actions.cairo
@@ -22,7 +22,6 @@ pub mod actions {
 
     use dojo::event::EventStorage;
     use dojo::model::ModelStorage;
-    use lyricsflip::constants::{GAME_ID, Genre};
     use lyricsflip::models::round::{Round, RoundState, Rounds, RoundsCount};
     use starknet::{ContractAddress, get_block_timestamp, get_caller_address};
     use super::{IActions, ID};

--- a/src/systems/actions.cairo
+++ b/src/systems/actions.cairo
@@ -44,8 +44,7 @@ pub mod actions {
                 genre: genre.into(),
                 wager_amount: 0, //TODO
                 start_time: get_block_timestamp(), //TODO
-                is_started: false,
-                is_completed: false,
+                state: RoundState::Pending,
                 end_time: 0, //TODO
                 next_card_index: 0,
                 players_count: 1,

--- a/src/systems/actions.cairo
+++ b/src/systems/actions.cairo
@@ -11,7 +11,7 @@ pub trait IActions<TContractState> {
 pub mod actions {
     use super::{IActions, ID};
     use starknet::{ContractAddress, get_caller_address, get_block_timestamp};
-    use lyricsflip::models::round::{RoundsCount, Round, Rounds};
+    use lyricsflip::models::round::{RoundsCount, Round, Rounds,RoundState};
     use lyricsflip::constants::{GAME_ID, Genre};
 
     use dojo::model::{ModelStorage};

--- a/src/systems/actions.cairo
+++ b/src/systems/actions.cairo
@@ -43,7 +43,7 @@ pub mod actions {
                 genre: genre.into(),
                 wager_amount: 0, //TODO
                 start_time: get_block_timestamp(), //TODO
-                state: RoundState::Pending,
+                state: RoundState::Pending.into(),
                 end_time: 0, //TODO
                 next_card_index: 0,
                 players_count: 1,

--- a/src/systems/actions.cairo
+++ b/src/systems/actions.cairo
@@ -1,5 +1,5 @@
-use lyricsflip::constants::{Genre};
-use lyricsflip::alias::{ID};
+use lyricsflip::alias::ID;
+use lyricsflip::constants::Genre;
 
 #[starknet::interface]
 pub trait IActions<TContractState> {
@@ -9,13 +9,12 @@ pub trait IActions<TContractState> {
 // dojo decorator
 #[dojo::contract]
 pub mod actions {
-    use super::{IActions, ID};
-    use starknet::{ContractAddress, get_caller_address, get_block_timestamp};
-    use lyricsflip::models::round::{RoundsCount, Round, Rounds,RoundState};
-    use lyricsflip::constants::{GAME_ID, Genre};
-
-    use dojo::model::{ModelStorage};
     use dojo::event::EventStorage;
+    use dojo::model::ModelStorage;
+    use lyricsflip::constants::{GAME_ID, Genre};
+    use lyricsflip::models::round::{Round, RoundState, Rounds, RoundsCount};
+    use starknet::{ContractAddress, get_block_timestamp, get_caller_address};
+    use super::{IActions, ID};
 
     #[derive(Drop, Copy, Serde)]
     #[dojo::event]

--- a/src/systems/config.cairo
+++ b/src/systems/config.cairo
@@ -1,4 +1,4 @@
-use lyricsflip::constants::{Genre};
+use lyricsflip::constants::Genre;
 use starknet::ContractAddress;
 
 #[starknet::interface]
@@ -10,17 +10,14 @@ pub trait IGameConfig<TContractState> {
 // dojo decorator
 #[dojo::contract]
 pub mod game_config {
-    use super::{IGameConfig};
-    use starknet::{ContractAddress, get_caller_address, get_block_timestamp};
-    use lyricsflip::models::config::{GameConfig};
-    use lyricsflip::constants::{GAME_ID};
-
     use core::num::traits::zero::Zero;
-
-    use dojo::model::{Model, ModelStorage};
-    use dojo::world::WorldStorage;
-    use dojo::world::{IWorldDispatcherTrait};
     use dojo::event::EventStorage;
+    use dojo::model::{Model, ModelStorage};
+    use dojo::world::{IWorldDispatcherTrait, WorldStorage};
+    use lyricsflip::constants::GAME_ID;
+    use lyricsflip::models::config::GameConfig;
+    use starknet::{ContractAddress, get_block_timestamp, get_caller_address};
+    use super::IGameConfig;
 
     #[abi(embed_v0)]
     impl GameConfigImpl of IGameConfig<ContractState> {

--- a/src/tests/test_world.cairo
+++ b/src/tests/test_world.cairo
@@ -10,6 +10,7 @@ mod tests {
     // use lyricsflip::models::card::{Card, m_Card};
     use lyricsflip::models::config::{GameConfig, m_GameConfig};
     use lyricsflip::models::round::{Rounds, RoundsCount, m_Rounds, m_RoundsCount};
+    use lyricsflip::models::round::RoundState;
     use lyricsflip::systems::actions::{IActionsDispatcher, IActionsDispatcherTrait, actions};
     use lyricsflip::systems::config::{
         IGameConfigDispatcher, IGameConfigDispatcherTrait, game_config,
@@ -69,6 +70,8 @@ mod tests {
         assert(res.round.wager_amount == 0, 'wrong round wager_amount');
         assert(res.round.start_time == 0, 'wrong round start_time');
         assert(res.round.players_count == 1, 'wrong players_count');
+        assert(res.round.state == RoundState::Pending.into(), 'Round state should be Pending');
+
 
         let round_id = actions_system.create_round(Genre::Pop.into());
 
@@ -79,60 +82,8 @@ mod tests {
         assert(res.round.creator == caller, 'round creator is wrong');
         assert(res.round.genre == Genre::Pop.into(), 'wrong round genre');
         assert(res.round.players_count == 1, 'wrong players_count');
-    }
+        assert(res.round.state == RoundState::Pending.into(), 'Round state should be Pending');
 
-    #[test]
-    fn test_set_cards_per_round() {
-        // Setup the test world
-        let ndef = namespace_def();
-        let mut world = spawn_test_world([ndef].span());
-        world.sync_perms_and_inits(contract_defs());
 
-        // Initialize GameConfig with default values
-        let admin = starknet::contract_address_const::<0x1>();
-        let _default_cards_per_round = 5_u32;
-
-        world
-            .write_model(@GameConfig { id: GAME_ID, cards_per_round: 5_u32, admin_address: admin });
-
-        // Get the game_config contract
-        let (contract_address, _) = world.dns(@"game_config").unwrap();
-        let game_config_system = IGameConfigDispatcher { contract_address };
-
-        // Test successful update
-        let new_cards_per_round = 10_u32;
-        game_config_system.set_cards_per_round(new_cards_per_round);
-
-        // Verify the update
-        let config: GameConfig = world.read_model(GAME_ID);
-        assert(config.cards_per_round == new_cards_per_round, 'cards_per_round not updated');
-        assert(config.admin_address == admin, 'admin address changed');
-
-        // Test with different valid value
-        let another_value = 15_u32;
-        game_config_system.set_cards_per_round(another_value);
-        let config: GameConfig = world.read_model(GAME_ID);
-        assert(config.cards_per_round == another_value, 'failed to update again');
-    }
-
-    #[test]
-    #[should_panic(expected: ('cards_per_round cannot be zero', 'ENTRYPOINT_FAILED'))]
-    fn test_set_cards_per_round_with_zero() {
-        // Setup the test world
-        let ndef = namespace_def();
-        let mut world = spawn_test_world([ndef].span());
-        world.sync_perms_and_inits(contract_defs());
-
-        // Initialize GameConfig with default values
-        let admin = starknet::contract_address_const::<0x1>();
-        world
-            .write_model(@GameConfig { id: GAME_ID, cards_per_round: 5_u32, admin_address: admin });
-
-        // Get the game_config contract
-        let (contract_address, _) = world.dns(@"game_config").unwrap();
-        let game_config_system = IGameConfigDispatcher { contract_address };
-
-        // Test with zero value (should panic)
-        game_config_system.set_cards_per_round(0);
     }
 }

--- a/src/tests/test_world.cairo
+++ b/src/tests/test_world.cairo
@@ -71,7 +71,6 @@ mod tests {
         assert(res.round.players_count == 1, 'wrong players_count');
         assert(res.round.state == RoundState::Pending.into(), 'Round state should be Pending');
 
-
         let round_id = actions_system.create_round(Genre::Pop.into());
 
         let res: Rounds = world.read_model(round_id);
@@ -82,8 +81,61 @@ mod tests {
         assert(res.round.genre == Genre::Pop.into(), 'wrong round genre');
         assert(res.round.players_count == 1, 'wrong players_count');
         assert(res.round.state == RoundState::Pending.into(), 'Round state should be Pending');
+    }
 
+    #[test]
+    fn test_set_cards_per_round() {
+        // Setup the test world
+        let ndef = namespace_def();
+        let mut world = spawn_test_world([ndef].span());
+        world.sync_perms_and_inits(contract_defs());
 
+        // Initialize GameConfig with default values
+        let admin = starknet::contract_address_const::<0x1>();
+        let _default_cards_per_round = 5_u32;
+
+        world
+            .write_model(@GameConfig { id: GAME_ID, cards_per_round: 5_u32, admin_address: admin });
+
+        // Get the game_config contract
+        let (contract_address, _) = world.dns(@"game_config").unwrap();
+        let game_config_system = IGameConfigDispatcher { contract_address };
+
+        // Test successful update
+        let new_cards_per_round = 10_u32;
+        game_config_system.set_cards_per_round(new_cards_per_round);
+
+        // Verify the update
+        let config: GameConfig = world.read_model(GAME_ID);
+        assert(config.cards_per_round == new_cards_per_round, 'cards_per_round not updated');
+        assert(config.admin_address == admin, 'admin address changed');
+
+        // Test with different valid value
+        let another_value = 15_u32;
+        game_config_system.set_cards_per_round(another_value);
+        let config: GameConfig = world.read_model(GAME_ID);
+        assert(config.cards_per_round == another_value, 'failed to update again');
+    }
+
+    #[test]
+    #[should_panic(expected: ('cards_per_round cannot be zero', 'ENTRYPOINT_FAILED'))]
+    fn test_set_cards_per_round_with_zero() {
+        // Setup the test world
+        let ndef = namespace_def();
+        let mut world = spawn_test_world([ndef].span());
+        world.sync_perms_and_inits(contract_defs());
+
+        // Initialize GameConfig with default values
+        let admin = starknet::contract_address_const::<0x1>();
+        world
+            .write_model(@GameConfig { id: GAME_ID, cards_per_round: 5_u32, admin_address: admin });
+
+        // Get the game_config contract
+        let (contract_address, _) = world.dns(@"game_config").unwrap();
+        let game_config_system = IGameConfigDispatcher { contract_address };
+
+        // Test with zero value (should panic)
+        game_config_system.set_cards_per_round(0);
     }
 
     #[test]

--- a/src/tests/test_world.cairo
+++ b/src/tests/test_world.cairo
@@ -1,21 +1,19 @@
 #[cfg(test)]
 mod tests {
-    use dojo_cairo_test::WorldStorageTestTrait;
     use dojo::model::{ModelStorage, ModelStorageTest};
     use dojo::world::WorldStorageTrait;
     use dojo_cairo_test::{
-        spawn_test_world, NamespaceDef, TestResource, ContractDefTrait, ContractDef,
+        ContractDef, ContractDefTrait, NamespaceDef, TestResource, WorldStorageTestTrait,
+        spawn_test_world,
     };
-
-    use lyricsflip::systems::actions::{actions, IActionsDispatcher, IActionsDispatcherTrait};
-    use lyricsflip::systems::config::{
-        game_config, IGameConfigDispatcher, IGameConfigDispatcherTrait,
-    };
-    use lyricsflip::models::round::{Rounds, m_Rounds, RoundsCount, m_RoundsCount};
+    use lyricsflip::constants::{GAME_ID, Genre};
     // use lyricsflip::models::card::{Card, m_Card};
     use lyricsflip::models::config::{GameConfig, m_GameConfig};
-    use lyricsflip::constants::{GAME_ID};
-    use lyricsflip::constants::{Genre};
+    use lyricsflip::models::round::{Rounds, RoundsCount, m_Rounds, m_RoundsCount};
+    use lyricsflip::systems::actions::{IActionsDispatcher, IActionsDispatcherTrait, actions};
+    use lyricsflip::systems::config::{
+        IGameConfigDispatcher, IGameConfigDispatcherTrait, game_config,
+    };
 
 
     fn namespace_def() -> NamespaceDef {

--- a/src/tests/test_world.cairo
+++ b/src/tests/test_world.cairo
@@ -70,8 +70,6 @@ mod tests {
         assert(res.round.genre == Genre::Rock.into(), 'wrong round genre');
         assert(res.round.wager_amount == 0, 'wrong round wager_amount');
         assert(res.round.start_time == 0, 'wrong round start_time');
-        assert(!res.round.is_started, 'is_started should be false');
-        assert(!res.round.is_completed, 'is_completed should be false');
         assert(res.round.players_count == 1, 'wrong players_count');
 
         let round_id = actions_system.create_round(Genre::Pop.into());


### PR DESCRIPTION
This PR refactors the contract to fully integrate the RoundState enum into the create_round function and ensures consistency across the codebase. It also updates the test suite to align with the changes, removing the deprecated is_started field and improving readability.

## Changes Implemented
    >1. Round State Refactor
        Introduced RoundState (Pending, Started, Completed) as the state representation for Round.
        Replaced is_started and is_completed with RoundState.
        Updated start() and complete() methods to transition the RoundState properly.
    2. Updates to create_round Function
        Ensured new rounds start with RoundState::Pending.
        Removed redundant boolean checks (is_started, is_completed).
    3. Tests Refactor
        Updated assertions to check RoundState instead of is_started.
        Removed outdated assertions that referenced is_started.
