### PR TITLE
Implement set_cards_per_round function with robust test coverage

### DIFF
--- a/src/systems/config.cairo
+++ b/src/systems/config.cairo
@@ -5,6 +5,7 @@ use starknet::ContractAddress;
 pub trait IGameConfig<TContractState> {
     //TODO
     fn set_game_config(ref self: TContractState, admin_address: ContractAddress);
+    fn set_cards_per_round(ref self: TContractState, cards_per_round: u32);
 }
 
 // dojo decorator
@@ -26,6 +27,23 @@ pub mod game_config {
     impl GameConfigImpl of IGameConfig<ContractState> {
         //TODO
         fn set_game_config(ref self: ContractState, admin_address: ContractAddress) {}
+        
+        fn set_cards_per_round(ref self: ContractState, cards_per_round: u32) {
+            // Check that the value being set is non-zero
+            assert(cards_per_round != 0, 'cards_per_round cannot be zero');
+            
+            // Get the world dispatcher
+            let mut world = self.world_default();
+            
+            // Get the current game config
+            let mut game_config: GameConfig = world.read_model(GAME_ID);
+            
+            // Update the cards_per_round field
+            game_config.cards_per_round = cards_per_round;
+            
+            // Save the updated game config back to the world
+            world.write_model(@game_config);
+        }
     }
 
     #[generate_trait]

--- a/src/systems/config.cairo
+++ b/src/systems/config.cairo
@@ -1,4 +1,3 @@
-use lyricsflip::constants::{Genre};
 use starknet::ContractAddress;
 
 #[starknet::interface]
@@ -12,35 +11,29 @@ pub trait IGameConfig<TContractState> {
 #[dojo::contract]
 pub mod game_config {
     use super::{IGameConfig};
-    use starknet::{ContractAddress, get_caller_address, get_block_timestamp};
+    use starknet::ContractAddress;
     use lyricsflip::models::config::{GameConfig};
     use lyricsflip::constants::{GAME_ID};
-
-    use core::num::traits::zero::Zero;
-
-    use dojo::model::{Model, ModelStorage};
-    use dojo::world::WorldStorage;
-    use dojo::world::{IWorldDispatcherTrait};
-    use dojo::event::EventStorage;
+    use dojo::model::ModelStorage;
 
     #[abi(embed_v0)]
     impl GameConfigImpl of IGameConfig<ContractState> {
         //TODO
         fn set_game_config(ref self: ContractState, admin_address: ContractAddress) {}
-        
+
         fn set_cards_per_round(ref self: ContractState, cards_per_round: u32) {
             // Check that the value being set is non-zero
             assert(cards_per_round != 0, 'cards_per_round cannot be zero');
-            
+
             // Get the world dispatcher
             let mut world = self.world_default();
-            
+
             // Get the current game config
             let mut game_config: GameConfig = world.read_model(GAME_ID);
-            
+
             // Update the cards_per_round field
             game_config.cards_per_round = cards_per_round;
-            
+
             // Save the updated game config back to the world
             world.write_model(@game_config);
         }

--- a/src/tests/test_world.cairo
+++ b/src/tests/test_world.cairo
@@ -115,12 +115,26 @@ mod tests {
         game_config_system.set_cards_per_round(another_value);
         let config: GameConfig = world.read_model(GAME_ID);
         assert(config.cards_per_round == another_value, 'failed to update again');
+    }
+    
+    #[test]
+    #[should_panic(expected: ('cards_per_round cannot be zero', 'ENTRYPOINT_FAILED'))]
+    fn test_set_cards_per_round_with_zero() {
+        // Setup the test world
+        let ndef = namespace_def();
+        let mut world = spawn_test_world([ndef].span());
+        world.sync_perms_and_inits(contract_defs());
+
+        // Initialize GameConfig with default values
+        let admin = starknet::contract_address_const::<0x1>();
+        world
+            .write_model(@GameConfig { id: GAME_ID, cards_per_round: 5_u32, admin_address: admin });
+
+        // Get the game_config contract
+        let (contract_address, _) = world.dns(@"game_config").unwrap();
+        let game_config_system = IGameConfigDispatcher { contract_address };
 
         // Test with zero value (should panic)
-        // Instead of using should_panic, we'll assert that attempting to set 0 would panic
-        let result = core::panic::catch_panic(|| {
-            game_config_system.set_cards_per_round(0);
-        });
-        assert(result.is_some(), 'should have panicked');
+        game_config_system.set_cards_per_round(0);
     }
 }

--- a/src/tests/test_world.cairo
+++ b/src/tests/test_world.cairo
@@ -116,7 +116,7 @@ mod tests {
         let config: GameConfig = world.read_model(GAME_ID);
         assert(config.cards_per_round == another_value, 'failed to update again');
     }
-    
+
     #[test]
     #[should_panic(expected: ('cards_per_round cannot be zero', 'ENTRYPOINT_FAILED'))]
     fn test_set_cards_per_round_with_zero() {


### PR DESCRIPTION
     This PR implements the set_cards_per_round function as requested in issue #15.
     
     Changes:
     - Added set_cards_per_round function to the IGameConfig interface
     - Implemented the function with proper validation for non-zero values
     - Added comprehensive test coverage in test_world.cairo
     
     The function has been tested locally and works as expected.