### PR TITLE
feat: implement `set_admin_address` function

### DIFF
--- a/src/systems/config.cairo
+++ b/src/systems/config.cairo
@@ -5,6 +5,7 @@ use starknet::ContractAddress;
 pub trait IGameConfig<TContractState> {
     //TODO
     fn set_game_config(ref self: TContractState, admin_address: ContractAddress);
+    fn set_admin_address(ref self: TContractState, admin_address: ContractAddress);
 }
 
 // dojo decorator
@@ -26,6 +27,18 @@ pub mod game_config {
     impl GameConfigImpl of IGameConfig<ContractState> {
         //TODO
         fn set_game_config(ref self: ContractState, admin_address: ContractAddress) {}
+
+        fn set_admin_address(ref self: ContractState, admin_address: ContractAddress) {
+            assert(
+                admin_address != Zero::<ContractAddress>::zero(), 'admin_address cannot be zero',
+            );
+
+            let mut world = self.world_default();
+            let mut game_config: GameConfig = world.read_model(GAME_ID);
+
+            game_config.admin_address = admin_address;
+            world.write_model(@game_config);
+        }
     }
 
     #[generate_trait]

--- a/src/tests/test_world.cairo
+++ b/src/tests/test_world.cairo
@@ -115,8 +115,5 @@ mod tests {
         let actions_system = IGameConfigDispatcher { contract_address };
 
         actions_system.set_admin_address(caller);
-
-        let config: GameConfig = world.read_model(GAME_ID);
-        assert(config.admin_address == caller, 'admin_address not updated');
     }
 }

--- a/src/tests/test_world.cairo
+++ b/src/tests/test_world.cairo
@@ -84,4 +84,39 @@ mod tests {
         assert(res.round.genre == Genre::Pop.into(), 'wrong round genre');
         assert(res.round.players_count == 1, 'wrong players_count');
     }
+
+    #[test]
+    fn test_set_admin_address() {
+        let caller = starknet::contract_address_const::<0x1>();
+
+        let ndef = namespace_def();
+        let mut world = spawn_test_world([ndef].span());
+        world.sync_perms_and_inits(contract_defs());
+
+        let (contract_address, _) = world.dns(@"game_config").unwrap();
+        let actions_system = IGameConfigDispatcher { contract_address };
+
+        actions_system.set_admin_address(caller);
+
+        let config: GameConfig = world.read_model(GAME_ID);
+        assert(config.admin_address == caller, 'admin_address not updated');
+    }
+
+    #[test]
+    #[should_panic(expected: ('admin_address cannot be zero', 'ENTRYPOINT_FAILED'))]
+    fn test_set_admin_address_panics_with_zero_address() {
+        let caller = starknet::contract_address_const::<0x0>();
+
+        let ndef = namespace_def();
+        let mut world = spawn_test_world([ndef].span());
+        world.sync_perms_and_inits(contract_defs());
+
+        let (contract_address, _) = world.dns(@"game_config").unwrap();
+        let actions_system = IGameConfigDispatcher { contract_address };
+
+        actions_system.set_admin_address(caller);
+
+        let config: GameConfig = world.read_model(GAME_ID);
+        assert(config.admin_address == caller, 'admin_address not updated');
+    }
 }


### PR DESCRIPTION
Hi, this PR implements the `set_admin_address` function which set the `admin_address` in `GameConfig`.

This function:
- Accepts an admin address as a parameter
- Asserts that the admin address is non-zero
- Reads the current GameConfig from the world state
- Updates the GameConfig with the new admin address

Staying available if any changes are needed.