### PR TITLE
[FEAT]: Add get_round_id function and tests for round ID consistency

### DIFF
--- a/src/systems/actions.cairo
+++ b/src/systems/actions.cairo
@@ -90,9 +90,6 @@ pub mod actions {
             // Get the default world.
             let mut world = self.world_default();
 
-            // get caller address
-            let caller = get_caller_address();
-
             let card_count: LyricsCardCount = world.read_model(GAME_ID);
             let card_id = card_count.count + 1;
 

--- a/src/systems/actions.cairo
+++ b/src/systems/actions.cairo
@@ -4,6 +4,7 @@ use lyricsflip::alias::{ID};
 #[starknet::interface]
 pub trait IActions<TContractState> {
     fn create_round(ref self: TContractState, genre: Genre) -> ID;
+    fn get_round_id(self: @TContractState) -> ID;
 }
 
 // dojo decorator
@@ -34,9 +35,8 @@ pub mod actions {
             // get caller address
             let caller = get_caller_address();
 
-            // compute next round ID from round counts
-            let rounds_count: RoundsCount = world.read_model(GAME_ID);
-            let round_id = rounds_count.count + 1;
+            // get the next round ID
+            let round_id = self.get_round_id();
 
             // new round
             let round = Round {
@@ -60,6 +60,16 @@ pub mod actions {
 
             round_id
         }
+
+        fn get_round_id(self: @ContractState) -> ID {
+            // Get the default world
+            let world = self.world_default();
+
+            // compute next round ID from round counts
+            let rounds_count: RoundsCount = world.read_model(GAME_ID);
+            rounds_count.count + 1
+        }
+
     }
 
     #[generate_trait]

--- a/src/tests/test_world.cairo
+++ b/src/tests/test_world.cairo
@@ -84,4 +84,62 @@ mod tests {
         assert(res.round.genre == Genre::Pop.into(), 'wrong round genre');
         assert(res.round.players_count == 1, 'wrong players_count');
     }
+
+    #[test]
+    fn test_get_round_id_initial_value() {
+        let caller = starknet::contract_address_const::<0x0>();
+
+        let ndef = namespace_def();
+        let mut world = spawn_test_world([ndef].span());
+        world.sync_perms_and_inits(contract_defs());
+
+        let (contract_address, _) = world.dns(@"actions").unwrap();
+        let actions_system = IActionsDispatcher { contract_address };
+
+        // Initial round_id should be 6
+        world.write_model(@RoundsCount { id: GAME_ID, count: 5_u256 });
+
+        // Get round_id using get_round_id
+        let round_id = actions_system.get_round_id();
+
+        // Should return 6 (5 + 1)
+        assert(round_id == 6_u256, 'Initial round_id should be 6');
+
+        // Verify that the counter did not change (get_round_id does not modify it)
+        let rounds_count: RoundsCount = world.read_model(GAME_ID);
+        assert(rounds_count.count == 5_u256, 'rounds count should remain 5');
+    }
+
+    #[test]
+    fn test_round_id_consistency() {
+        let caller = starknet::contract_address_const::<0x0>();
+
+        let ndef = namespace_def();
+        let mut world = spawn_test_world([ndef].span());
+        world.sync_perms_and_inits(contract_defs());
+
+        let (contract_address, _) = world.dns(@"actions").unwrap();
+        let actions_system = IActionsDispatcher { contract_address };
+
+        // Get the first round ID without creating a round
+        let expected_round_id = actions_system.get_round_id();
+
+        // Create a round and verify that the ID is the same as the one obtained before
+        let actual_round_id = actions_system.create_round(Genre::Jazz.into());
+        assert(actual_round_id == expected_round_id, 'Round IDs should match');
+
+        // Get the next round ID
+        let next_expected_id = actions_system.get_round_id();
+
+        // Verify that the next ID is the previous one + 1
+        assert(next_expected_id == expected_round_id + 1_u256, 'Next ID should increment by 1');
+
+        // Create another round and verify that the ID matches the expected one
+        let next_actual_id = actions_system.create_round(Genre::Rock.into());
+        assert(next_actual_id == next_expected_id, 'Next round IDs should match');
+
+        // Verify the rounds counter
+        let rounds_count: RoundsCount = world.read_model(GAME_ID);
+        assert(rounds_count.count == 2_u256, 'rounds count should be 2');
+    }
 }

--- a/src/tests/test_world.cairo
+++ b/src/tests/test_world.cairo
@@ -248,5 +248,4 @@ mod tests {
         let rounds_count: RoundsCount = world.read_model(GAME_ID);
         assert(rounds_count.count == 2_u256, 'rounds count should be 2');
     }
-
 }

--- a/src/tests/test_world.cairo
+++ b/src/tests/test_world.cairo
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod tests {
-    use dojo::model::{ModelStorage, ModelStorageTest};
+    use dojo::model::{ModelStorage};
     use dojo::world::WorldStorageTrait;
     use dojo_cairo_test::{
         ContractDef, ContractDefTrait, NamespaceDef, TestResource, WorldStorageTestTrait,
@@ -139,8 +139,6 @@ mod tests {
 
     #[test]
     fn test_add_lyrics_card() {
-        let caller = starknet::contract_address_const::<0x0>();
-
         let ndef = namespace_def();
         let mut world = spawn_test_world([ndef].span());
         world.sync_perms_and_inits(contract_defs());
@@ -199,8 +197,6 @@ mod tests {
 
     #[test]
     fn test_get_round_id_initial_value() {
-        let caller = starknet::contract_address_const::<0x0>();
-
         let ndef = namespace_def();
         let mut world = spawn_test_world([ndef].span());
         world.sync_perms_and_inits(contract_defs());
@@ -224,8 +220,6 @@ mod tests {
 
     #[test]
     fn test_round_id_consistency() {
-        let caller = starknet::contract_address_const::<0x0>();
-
         let ndef = namespace_def();
         let mut world = spawn_test_world([ndef].span());
         world.sync_perms_and_inits(contract_defs());


### PR DESCRIPTION
# Extract round id functionality into a separate function

## Changes

- **Created a dedicated `get_round_id()` function** that calculates the next round ID.
- **Updated `create_round()`** to use this new function.
- **Added integration tests** to validate the expected behavior.

## Implementation

The round ID calculation has been extracted from `create_round()` to improve modularity and code organization, following the **single-responsibility principle**.

## Notes

- You can improve your ```tests``` folder by adding an utils.cairo to place ```namespace_def```, ```contract_def``` etc and avoid all those calls in every single integration test.
- You can add unit tests in the same model files.
- You can create a types file to have a ```genre.cairo``` file there, managing enums and conversions there, because constants it's more for inmutable values like ```let MAXIMUN_ROUNDS: u16 = 10;```