### PR TITLE
Implement is_round_player Function

### DIFF
--- a/src/systems/actions.cairo
+++ b/src/systems/actions.cairo
@@ -1,5 +1,6 @@
 use lyricsflip::alias::ID;
 use lyricsflip::constants::Genre;
+use starknet::ContractAddress;
 
 #[starknet::interface]
 pub trait IActions<TContractState> {
@@ -14,6 +15,7 @@ pub trait IActions<TContractState> {
         year: u64,
         lyrics: ByteArray,
     ) -> u256;
+    fn is_round_player(self: @TContractState, round_id: u256, player: ContractAddress) -> bool;
 }
 
 // dojo decorator
@@ -145,6 +147,17 @@ pub mod actions {
             world.write_model(@new_card);
 
             card_id
+        }
+
+        fn is_round_player(self: @ContractState, round_id: u256, player: ContractAddress) -> bool {
+            // Get the default world.
+            let world = self.world_default();
+            // Get the round player
+            let round_player: RoundPlayer = world.read_model((player, round_id));
+
+            // Return the joined boolean which signifies if the player is a participant of the round
+            // or not
+            round_player.joined
         }
     }
 

--- a/src/tests/test_world.cairo
+++ b/src/tests/test_world.cairo
@@ -93,7 +93,7 @@ mod tests {
 
     #[test]
     fn test_join_round() {
-        // Test player cannot join round if round has started
+        // Test player can join round successfully
 
         let caller = starknet::contract_address_const::<0x0>();
         let player = starknet::contract_address_const::<0x1>();
@@ -365,5 +365,54 @@ mod tests {
         // Verify the rounds counter
         let rounds_count: RoundsCount = world.read_model(GAME_ID);
         assert(rounds_count.count == 2_u256, 'rounds count should be 2');
+    }
+
+    #[test]
+    fn test_is_round_player_true() {
+        // Test player is a participant of the round
+
+        let caller = starknet::contract_address_const::<0x0>();
+        let player = starknet::contract_address_const::<0x1>();
+
+        let ndef = namespace_def();
+        let mut world = spawn_test_world([ndef].span());
+        world.sync_perms_and_inits(contract_defs());
+
+        let (contract_address, _) = world.dns(@"actions").unwrap();
+        let actions_system = IActionsDispatcher { contract_address };
+
+        // create round
+        let round_id = actions_system.create_round(Genre::Rock.into());
+
+        //join round
+        testing::set_contract_address(player);
+        actions_system.join_round(round_id);
+
+        let round_player: RoundPlayer = world.read_model((player, round_id));
+
+        // Check if player is a participant of the round
+        assert(round_player.joined, 'player not joined');
+    }
+
+    #[test]
+    fn test_is_round_player_false() {
+        // Test player is not a participant of the round
+
+        let caller = starknet::contract_address_const::<0x0>();
+        let player = starknet::contract_address_const::<0x1>();
+
+        let ndef = namespace_def();
+        let mut world = spawn_test_world([ndef].span());
+        world.sync_perms_and_inits(contract_defs());
+
+        let (contract_address, _) = world.dns(@"actions").unwrap();
+        let actions_system = IActionsDispatcher { contract_address };
+
+        // create round
+        let round_id = actions_system.create_round(Genre::Rock.into());
+        let round_player: RoundPlayer = world.read_model((player, round_id));
+
+        // Check if player is not a participant of the round
+        assert(!round_player.joined, 'player joined');
     }
 }

--- a/src/tests/test_world.cairo
+++ b/src/tests/test_world.cairo
@@ -388,10 +388,10 @@ mod tests {
         testing::set_contract_address(player);
         actions_system.join_round(round_id);
 
-        let round_player: RoundPlayer = world.read_model((player, round_id));
+        let is_round_player = actions_system.is_round_player(round_id, player);
 
         // Check if player is a participant of the round
-        assert(round_player.joined, 'player not joined');
+        assert(is_round_player, 'player not joined');
     }
 
     #[test]
@@ -410,9 +410,9 @@ mod tests {
 
         // create round
         let round_id = actions_system.create_round(Genre::Rock.into());
-        let round_player: RoundPlayer = world.read_model((player, round_id));
+        let is_round_player = actions_system.is_round_player(round_id, player);
 
         // Check if player is not a participant of the round
-        assert(!round_player.joined, 'player joined');
+        assert(!is_round_player, 'player joined');
     }
 }


### PR DESCRIPTION
 ## Overview
This PR adds the `is_round_player`  function to validate player participation in a specific game round. The function provides a mechanism for checking player participation.

## Key Changes
- Implemented `is_round_player` function
- Added logic to check player's participation in a round
- Integrated with existing world model storage

## Function Details
- Signature: `fn is_round_player(self: @ContractState, round_id: u256, player: ContractAddress) -> bool`
- Retrieves RoundPlayer model from world storage
- Returns boolean indicating player's round participation

## Functionality
- Efficiently checks if a player joined a specific round
- Returns `true` if player has joined the round
- Returns `false` if player is not a participant

## Testing
 - Check if a player is a round participant
 - Check if a player is not a round participant

Close #12 