### PR TITLE
Implement Year-Based Card Grouping with YearCards Model

### DIFF
--- a/src/lib.cairo
+++ b/src/lib.cairo
@@ -1,9 +1,16 @@
-pub mod models;
+pub mod models {
+    pub mod card;
+    pub mod year_cards;
+    pub mod round;
+    pub mod config;
+}
+
 pub mod systems;
 
 pub mod tests {
     mod test_world;
 }
+
 pub mod alias;
 
 pub mod constants;

--- a/src/models/year_cards.cairo
+++ b/src/models/year_cards.cairo
@@ -1,0 +1,7 @@
+#[derive(Clone, Drop, Serde, Debug)]
+#[dojo::model]
+pub struct YearCards {
+    #[key]
+    pub year: u64,              // The year as the unique key for grouping cards (u64 to match LyricsCard).
+    pub cards: Span<u256>,      // A Span of card_ids associated with this year (u256 to match card_id).
+}

--- a/src/systems/actions.cairo
+++ b/src/systems/actions.cairo
@@ -1,6 +1,13 @@
 use lyricsflip::alias::ID;
 use lyricsflip::constants::Genre;
 use starknet::ContractAddress;
+use lyricsflip::models::year_cards::YearCards;
+use core::array::{ArrayTrait, SpanTrait};
+use dojo::model::ModelStorage;
+use dojo::event::EventStorage;
+
+
+
 
 #[starknet::interface]
 pub trait IActions<TContractState> {
@@ -26,6 +33,8 @@ pub mod actions {
 
     use dojo::event::EventStorage;
     use dojo::model::ModelStorage;
+    use lyricsflip::models::year_cards::YearCards;
+    use core::array::{ArrayTrait, SpanTrait};
     use lyricsflip::models::round::{Round, RoundState, Rounds, RoundsCount, RoundPlayer};
     use starknet::{ContractAddress, get_block_timestamp, get_caller_address};
     use super::{IActions, ID};
@@ -127,27 +136,39 @@ pub mod actions {
             rounds_count.count + 1
         }
 
-        fn add_lyrics_card(
-            ref self: ContractState,
-            genre: Genre,
-            artist: felt252,
-            title: felt252,
-            year: u64,
-            lyrics: ByteArray,
-        ) -> u256 {
-            // Get the default world.
-            let mut world = self.world_default();
+    fn add_lyrics_card(ref self: ContractState, genre: Genre, artist: felt252, title: felt252, year: u64, lyrics: ByteArray) -> u256 {
+    let mut world = self.world_default();
 
-            let card_count: LyricsCardCount = world.read_model(GAME_ID);
-            let card_id = card_count.count + 1;
+    let card_count: LyricsCardCount = world.read_model(GAME_ID);
+    let card_id = card_count.count + 1;
 
-            let new_card = LyricsCard { card_id, genre: genre.into(), artist, title, year, lyrics };
+    let new_card = LyricsCard { card_id, genre: genre.into(), artist, title, year, lyrics };
+    world.write_model(@new_card);
 
-            // write new round to world
-            world.write_model(@new_card);
+    world.write_model(@LyricsCardCount { id: GAME_ID, count: card_id });
 
-            card_id
+    let mut year_cards = YearCards { year, cards: ArrayTrait::new().span() };
+    let existing_year_cards: YearCards = world.read_model(year);
+    if existing_year_cards.year != 0 {
+        year_cards = existing_year_cards;
+    }
+
+    let mut new_cards: Array<u256> = ArrayTrait::new();
+    let mut i = 0;
+    loop {
+        if i >= year_cards.cards.len() {
+            break;
         }
+        new_cards.append(*year_cards.cards[i]);
+        i += 1;
+    };
+    new_cards.append(card_id);
+
+    let updated_year_cards = YearCards { year, cards: new_cards.span() };
+    world.write_model(@updated_year_cards);
+
+    card_id
+    }
 
         fn is_round_player(self: @ContractState, round_id: u256, player: ContractAddress) -> bool {
             // Get the default world.
@@ -161,6 +182,7 @@ pub mod actions {
         }
     }
 
+    
     #[generate_trait]
     impl InternalImpl of InternalTrait {
         /// Use the default namespace "dojo_starter". This function is handy since the ByteArray
@@ -170,3 +192,4 @@ pub mod actions {
         }
     }
 }
+

--- a/src/tests/test_world.cairo
+++ b/src/tests/test_world.cairo
@@ -1,7 +1,7 @@
 #[cfg(test)]
 mod tests {
     use starknet::testing;
-    use dojo::model::{ModelStorage, ModelStorageTest};
+    use dojo::model::ModelStorage;
     use dojo::world::WorldStorageTrait;
     use dojo_cairo_test::{
         ContractDef, ContractDefTrait, NamespaceDef, TestResource, WorldStorageTestTrait,
@@ -17,8 +17,8 @@ mod tests {
     use lyricsflip::systems::config::{
         IGameConfigDispatcher, IGameConfigDispatcherTrait, game_config,
     };
-    use lyricsflip::models::card::{LyricsCard, m_LyricsCard};
-
+    use lyricsflip::models::card::{LyricsCard, LyricsCardCount, m_LyricsCard, m_LyricsCardCount};
+    use lyricsflip::models::year_cards::{YearCards, m_YearCards};
 
     fn namespace_def() -> NamespaceDef {
         let ndef = NamespaceDef {
@@ -28,6 +28,8 @@ mod tests {
                 TestResource::Model(m_RoundsCount::TEST_CLASS_HASH),
                 TestResource::Model(m_RoundPlayer::TEST_CLASS_HASH),
                 TestResource::Model(m_LyricsCard::TEST_CLASS_HASH),
+                TestResource::Model(m_LyricsCardCount::TEST_CLASS_HASH),
+                TestResource::Model(m_YearCards::TEST_CLASS_HASH),
                 TestResource::Model(m_GameConfig::TEST_CLASS_HASH),
                 TestResource::Event(actions::e_RoundCreated::TEST_CLASS_HASH),
                 TestResource::Event(actions::e_RoundJoined::TEST_CLASS_HASH),
@@ -44,8 +46,6 @@ mod tests {
         [
             ContractDefTrait::new(@"lyricsflip", @"actions")
                 .with_writer_of([dojo::utils::bytearray_hash(@"lyricsflip")].span()),
-            // ContractDefTrait::new(@"lyricsflip", @"cards")
-            //     .with_writer_of([dojo::utils::bytearray_hash(@"lyricsflip")].span()),
             ContractDefTrait::new(@"lyricsflip", @"game_config")
                 .with_writer_of([dojo::utils::bytearray_hash(@"lyricsflip")].span()),
         ]
@@ -93,8 +93,6 @@ mod tests {
 
     #[test]
     fn test_join_round() {
-        // Test player can join round successfully
-
         let caller = starknet::contract_address_const::<0x0>();
         let player = starknet::contract_address_const::<0x1>();
 
@@ -105,30 +103,24 @@ mod tests {
         let (contract_address, _) = world.dns(@"actions").unwrap();
         let actions_system = IActionsDispatcher { contract_address };
 
-        // create round
         let round_id = actions_system.create_round(Genre::Rock.into());
 
         let res: Rounds = world.read_model(round_id);
         assert(res.round.players_count == 1, 'wrong players_count');
 
-        //join round
         testing::set_contract_address(player);
         actions_system.join_round(round_id);
 
         let res: Rounds = world.read_model(round_id);
         let round_player: RoundPlayer = world.read_model((player, round_id));
 
-        // Check if player count increased by 1
         assert(res.round.players_count == 2, 'wrong players_count');
-        // Check if round player has joined
         assert(round_player.joined, 'player not joined');
     }
 
     #[test]
     #[should_panic]
     fn test_cannot_join_round_non_existent_round() {
-        // Test player cannot join round if round does not exist
-
         let caller = starknet::contract_address_const::<0x0>();
         let player = starknet::contract_address_const::<0x1>();
 
@@ -139,16 +131,13 @@ mod tests {
         let (contract_address, _) = world.dns(@"actions").unwrap();
         let actions_system = IActionsDispatcher { contract_address };
 
-        //join round
         testing::set_caller_address(player);
-        actions_system.join_round(1); // should panic
+        actions_system.join_round(1);
     }
 
     #[test]
     #[should_panic]
     fn test_cannot_join_ongoing_round() {
-        // Test player cannot join round if round has started
-
         let caller = starknet::contract_address_const::<0x0>();
         let player = starknet::contract_address_const::<0x1>();
 
@@ -159,28 +148,21 @@ mod tests {
         let (contract_address, _) = world.dns(@"actions").unwrap();
         let actions_system = IActionsDispatcher { contract_address };
 
-        // create round
         let round_id = actions_system.create_round(Genre::Rock.into());
 
         let mut res: Rounds = world.read_model(round_id);
         assert(res.round.players_count == 1, 'wrong players_count');
 
-        // mark round as started
         res.round.state = RoundState::Started.into();
-
-        // update round in world
         world.write_model(@res);
 
-        //join round
         testing::set_contract_address(player);
-        actions_system.join_round(round_id); // should panic
+        actions_system.join_round(round_id);
     }
 
     #[test]
     #[should_panic]
     fn test_cannot_join_already_joined_round() {
-        // Test player cannot join round if player has already joined round.
-
         let caller = starknet::contract_address_const::<0x0>();
 
         let ndef = namespace_def();
@@ -190,44 +172,36 @@ mod tests {
         let (contract_address, _) = world.dns(@"actions").unwrap();
         let actions_system = IActionsDispatcher { contract_address };
 
-        // create round
         let round_id = actions_system.create_round(Genre::Rock.into());
 
         let mut res: Rounds = world.read_model(round_id);
         assert(res.round.players_count == 1, 'wrong players_count');
 
-        //join round
-        actions_system.join_round(round_id); // should panic as player already created round
+        actions_system.join_round(round_id);
     }
 
     #[test]
     fn test_set_cards_per_round() {
-        // Setup the test world
         let ndef = namespace_def();
         let mut world = spawn_test_world([ndef].span());
         world.sync_perms_and_inits(contract_defs());
 
-        // Initialize GameConfig with default values
         let admin = starknet::contract_address_const::<0x1>();
         let _default_cards_per_round = 5_u32;
 
         world
             .write_model(@GameConfig { id: GAME_ID, cards_per_round: 5_u32, admin_address: admin });
 
-        // Get the game_config contract
         let (contract_address, _) = world.dns(@"game_config").unwrap();
         let game_config_system = IGameConfigDispatcher { contract_address };
 
-        // Test successful update
         let new_cards_per_round = 10_u32;
         game_config_system.set_cards_per_round(new_cards_per_round);
 
-        // Verify the update
         let config: GameConfig = world.read_model(GAME_ID);
         assert(config.cards_per_round == new_cards_per_round, 'cards_per_round not updated');
         assert(config.admin_address == admin, 'admin address changed');
 
-        // Test with different valid value
         let another_value = 15_u32;
         game_config_system.set_cards_per_round(another_value);
         let config: GameConfig = world.read_model(GAME_ID);
@@ -237,21 +211,17 @@ mod tests {
     #[test]
     #[should_panic(expected: ('cards_per_round cannot be zero', 'ENTRYPOINT_FAILED'))]
     fn test_set_cards_per_round_with_zero() {
-        // Setup the test world
         let ndef = namespace_def();
         let mut world = spawn_test_world([ndef].span());
         world.sync_perms_and_inits(contract_defs());
 
-        // Initialize GameConfig with default values
         let admin = starknet::contract_address_const::<0x1>();
         world
             .write_model(@GameConfig { id: GAME_ID, cards_per_round: 5_u32, admin_address: admin });
 
-        // Get the game_config contract
         let (contract_address, _) = world.dns(@"game_config").unwrap();
         let game_config_system = IGameConfigDispatcher { contract_address };
 
-        // Test with zero value (should panic)
         game_config_system.set_cards_per_round(0);
     }
 
@@ -261,6 +231,9 @@ mod tests {
         let mut world = spawn_test_world([ndef].span());
         world.sync_perms_and_inits(contract_defs());
 
+        // Inicializamos LyricsCardCount
+        world.write_model(@LyricsCardCount { id: GAME_ID, count: 0_u256 });
+
         let (contract_address, _) = world.dns(@"actions").unwrap();
         let actions_system = IActionsDispatcher { contract_address };
 
@@ -268,17 +241,120 @@ mod tests {
         let artist = 'fame';
         let title = 'sounds';
         let year = 2020;
-        let lyrics = format!("come to life...");
+        let lyrics: ByteArray = "come to life...";
 
         let card_id = actions_system.add_lyrics_card(genre, artist, title, year, lyrics.clone());
 
+        // Verificamos el LyricsCard
         let card: LyricsCard = world.read_model(card_id);
-
+        assert(card.card_id == 1_u256, 'wrong card_id');
         assert(card.genre == 'Pop', 'wrong genre');
         assert(card.artist == artist, 'wrong artist');
         assert(card.title == title, 'wrong title');
         assert(card.year == year, 'wrong year');
         assert(card.lyrics == lyrics, 'wrong lyrics');
+
+        // Verificamos el LyricsCardCount
+        let card_count: LyricsCardCount = world.read_model(GAME_ID);
+        assert(card_count.count == 1_u256, 'wrong card count');
+
+        // Verificamos el YearCards
+        let year_cards: YearCards = world.read_model(year);
+        assert(year_cards.year == year, 'wrong year in YearCards');
+        assert(year_cards.cards.len() == 1, 'should have 1 card');
+        assert(*year_cards.cards[0] == card_id, 'wrong card_id in YearCards');
+    }
+
+    #[test]
+    fn test_add_multiple_lyrics_cards_same_year() {
+        let ndef = namespace_def();
+        let mut world = spawn_test_world([ndef].span());
+        world.sync_perms_and_inits(contract_defs());
+
+        // Inicializamos LyricsCardCount
+        world.write_model(@LyricsCardCount { id: GAME_ID, count: 0_u256 });
+
+        let (contract_address, _) = world.dns(@"actions").unwrap();
+        let actions_system = IActionsDispatcher { contract_address };
+
+        let year = 2020;
+        let genre1 = Genre::Pop;
+        let genre2 = Genre::Rock;
+        let artist1 = 'artist1';
+        let artist2 = 'artist2';
+        let title1 = 'title1';
+        let title2 = 'title2';
+        let lyrics1: ByteArray = "lyrics for card 1";
+        let lyrics2: ByteArray = "lyrics for card 2";
+
+        // Agregamos la primera tarjeta
+        let card_id1 = actions_system.add_lyrics_card(genre1, artist1, title1, year, lyrics1.clone());
+        // Agregamos la segunda tarjeta en el mismo año
+        let card_id2 = actions_system.add_lyrics_card(genre2, artist2, title2, year, lyrics2.clone());
+
+        // Verificamos los card_id
+        assert(card_id1 == 1_u256, 'wrong card_id 1');
+        assert(card_id2 == 2_u256, 'wrong card_id 2');
+
+        // Verificamos el LyricsCardCount
+        let card_count: LyricsCardCount = world.read_model(GAME_ID);
+        assert(card_count.count == 2_u256, 'wrong card count');
+
+        // Verificamos el YearCards
+        let year_cards: YearCards = world.read_model(year);
+        assert(year_cards.year == year, 'wrong year in YearCards');
+        assert(year_cards.cards.len() == 2, 'should have 2 cards');
+        assert(*year_cards.cards[0] == card_id1, 'wrong card_id 1 in YearCards');
+        assert(*year_cards.cards[1] == card_id2, 'wrong card_id 2 in YearCards');
+    }
+
+    #[test]
+    fn test_add_lyrics_cards_different_years() {
+        let ndef = namespace_def();
+        let mut world = spawn_test_world([ndef].span());
+        world.sync_perms_and_inits(contract_defs());
+
+        // Inicializamos LyricsCardCount
+        world.write_model(@LyricsCardCount { id: GAME_ID, count: 0_u256 });
+
+        let (contract_address, _) = world.dns(@"actions").unwrap();
+        let actions_system = IActionsDispatcher { contract_address };
+
+        let year1 = 2020;
+        let year2 = 2021;
+        let genre1 = Genre::Pop;
+        let genre2 = Genre::Rock;
+        let artist1 = 'artist1';
+        let artist2 = 'artist2';
+        let title1 = 'title1';
+        let title2 = 'title2';
+        let lyrics1: ByteArray = "lyrics for 2020";
+        let lyrics2: ByteArray = "lyrics for 2021";
+
+        // Agregamos la primera tarjeta (año 2020)
+        let card_id1 = actions_system.add_lyrics_card(genre1, artist1, title1, year1, lyrics1.clone());
+        // Agregamos la segunda tarjeta (año 2021)
+        let card_id2 = actions_system.add_lyrics_card(genre2, artist2, title2, year2, lyrics2.clone());
+
+        // Verificamos los card_id
+        assert(card_id1 == 1_u256, 'wrong card_id 1');
+        assert(card_id2 == 2_u256, 'wrong card_id 2');
+
+        // Verificamos el LyricsCardCount
+        let card_count: LyricsCardCount = world.read_model(GAME_ID);
+        assert(card_count.count == 2_u256, 'wrong card count');
+
+        // Verificamos el YearCards para el año 2020
+        let year_cards1: YearCards = world.read_model(year1);
+        assert(year_cards1.year == year1, 'wrong year in YearCards 1');
+        assert(year_cards1.cards.len() == 1, 'should have 1 card in 2020');
+        assert(*year_cards1.cards[0] == card_id1, 'wrong card_id in YearCards 1');
+
+        // Verificamos el YearCards para el año 2021
+        let year_cards2: YearCards = world.read_model(year2);
+        assert(year_cards2.year == year2, 'wrong year in YearCards 2');
+        assert(year_cards2.cards.len() == 1, 'should have 1 card in 2021');
+        assert(*year_cards2.cards[0] == card_id2, 'wrong card_id in YearCards 2');
     }
 
     #[test]
@@ -322,16 +398,12 @@ mod tests {
         let (contract_address, _) = world.dns(@"actions").unwrap();
         let actions_system = IActionsDispatcher { contract_address };
 
-        // Initial round_id should be 6
         world.write_model(@RoundsCount { id: GAME_ID, count: 5_u256 });
 
-        // Get round_id using get_round_id
         let round_id = actions_system.get_round_id();
 
-        // Should return 6 (5 + 1)
         assert(round_id == 6_u256, 'Initial round_id should be 6');
 
-        // Verify that the counter did not change (get_round_id does not modify it)
         let rounds_count: RoundsCount = world.read_model(GAME_ID);
         assert(rounds_count.count == 5_u256, 'rounds count should remain 5');
     }
@@ -345,32 +417,24 @@ mod tests {
         let (contract_address, _) = world.dns(@"actions").unwrap();
         let actions_system = IActionsDispatcher { contract_address };
 
-        // Get the first round ID without creating a round
         let expected_round_id = actions_system.get_round_id();
 
-        // Create a round and verify that the ID is the same as the one obtained before
         let actual_round_id = actions_system.create_round(Genre::Jazz.into());
         assert(actual_round_id == expected_round_id, 'Round IDs should match');
 
-        // Get the next round ID
         let next_expected_id = actions_system.get_round_id();
 
-        // Verify that the next ID is the previous one + 1
         assert(next_expected_id == expected_round_id + 1_u256, 'Next ID should increment by 1');
 
-        // Create another round and verify that the ID matches the expected one
         let next_actual_id = actions_system.create_round(Genre::Rock.into());
         assert(next_actual_id == next_expected_id, 'Next round IDs should match');
 
-        // Verify the rounds counter
         let rounds_count: RoundsCount = world.read_model(GAME_ID);
         assert(rounds_count.count == 2_u256, 'rounds count should be 2');
     }
 
     #[test]
     fn test_is_round_player_true() {
-        // Test player is a participant of the round
-
         let caller = starknet::contract_address_const::<0x0>();
         let player = starknet::contract_address_const::<0x1>();
 
@@ -381,23 +445,18 @@ mod tests {
         let (contract_address, _) = world.dns(@"actions").unwrap();
         let actions_system = IActionsDispatcher { contract_address };
 
-        // create round
         let round_id = actions_system.create_round(Genre::Rock.into());
 
-        //join round
         testing::set_contract_address(player);
         actions_system.join_round(round_id);
 
         let is_round_player = actions_system.is_round_player(round_id, player);
 
-        // Check if player is a participant of the round
         assert(is_round_player, 'player not joined');
     }
 
     #[test]
     fn test_is_round_player_false() {
-        // Test player is not a participant of the round
-
         let caller = starknet::contract_address_const::<0x0>();
         let player = starknet::contract_address_const::<0x1>();
 
@@ -408,11 +467,9 @@ mod tests {
         let (contract_address, _) = world.dns(@"actions").unwrap();
         let actions_system = IActionsDispatcher { contract_address };
 
-        // create round
         let round_id = actions_system.create_round(Genre::Rock.into());
         let is_round_player = actions_system.is_round_player(round_id, player);
 
-        // Check if player is not a participant of the round
         assert(!is_round_player, 'player joined');
     }
 }


### PR DESCRIPTION
This PR implements the year-based grouping of lyrics cards using the new `YearCards` model, as per the issue requirements. It includes:

- Creation of the `YearCards` model with `year` as the key and `cards` as a `Span<u256>`.
- Modification of the `add_lyrics_card` function to update the `YearCards` model by adding the new card ID.
- Robust test coverage with tests for:
  - Basic card addition with year grouping (`test_add_lyrics_card`).
  - Adding multiple cards in the same year (`test_add_multiple_lyrics_cards_same_year`).
  - Adding cards in different years (`test_add_lyrics_cards_different_years`).All tests pass successfully, confirming the functionality works as expected.
  - Update Test_world.cairo