### PR TITLE
Feat: Round Validation System Implementation

### DIFF
--- a/src/models/round/round.cairo
+++ b/src/models/round/round.cairo
@@ -88,8 +88,7 @@ pub impl RoundImpl of RoundTrait {
             error_message = 'Wager amount cannot be zero';
         }
 
-
-        if *config.mode == Mode::Solo{
+        if *config.mode == Mode::Solo {
             if *config.max_players != 1 {
                 is_valid = false;
                 error_message = 'Solo mode must have one player';
@@ -112,86 +111,82 @@ pub impl RoundImpl of RoundTrait {
         }
 
         match *config.challenge_type {
-        Option::Some(challenge_type) => {
-            if challenge_type.requires_param() {
-                match config.challenge_param1 {
-                    Option::Some(param1) => {
-                        if *param1 == 0 {
+            Option::Some(challenge_type) => {
+                if challenge_type.requires_param() {
+                    match config.challenge_param1 {
+                        Option::Some(param1) => {
+                            if *param1 == 0 {
+                                is_valid = false;
+                                error_message = 'Challenge param1 cannot be zero';
+                            }
+                        },
+                        Option::None => {
                             is_valid = false;
-                            error_message = 'Challenge param1 cannot be zero';
-                        }
-                    },
-                    Option::None => {
+                            error_message = 'Challenge param1 required';
+                        },
+                    }
+
+                    match config.challenge_param2 {
+                        Option::Some(param2) => {
+                            if challenge_type != ChallengeType::GenreAndDecade {
+                                is_valid = false;
+                                error_message = 'Challenge param2 not required';
+                            }
+                        },
+                        Option::None => {// No action needed, param2 is optional
+                        },
+                    }
+                }
+
+                if challenge_type.requires_two_params() {
+                    match config.challenge_param2 {
+                        Option::Some(param2) => {
+                            if *param2 == 0 {
+                                is_valid = false;
+                                error_message = 'Challenge param2 cannot be zero';
+                            }
+                        },
+                        Option::None => {
+                            is_valid = false;
+                            error_message = 'Challenge param2 required';
+                        },
+                    }
+
+                    match config.challenge_param1 {
+                        Option::Some(param1) => {
+                            if *param1 == 0 {
+                                is_valid = false;
+                                error_message = 'Challenge param1 cannot be zero';
+                            }
+                        },
+                        Option::None => {
+                            is_valid = false;
+                            error_message = 'Both challenge params required';
+                        },
+                    }
+                }
+
+                if challenge_type == ChallengeType::Random {
+                    if config.challenge_param1.is_some() || config.challenge_param2.is_some() {
                         is_valid = false;
-                        error_message = 'Challenge param1 required';
+                        error_message = 'Random challenge has params';
                     }
                 }
 
-                match config.challenge_param2 {
-                    Option::Some(param2) => {
-                        if challenge_type != ChallengeType::GenreAndDecade{
-                            is_valid = false;
-                            error_message = 'Challenge param2 not required';
-                        }
-                    },
-                    Option::None => {
-                        // No action needed, param2 is optional
-                    }
-                }
-            }
-
-            if challenge_type.requires_two_params() {
-                match config.challenge_param2 {
-                    Option::Some(param2) => {
-                        if *param2 == 0 {
-                            is_valid = false;
-                            error_message = 'Challenge param2 cannot be zero';
-                        }
-                    },
-                    Option::None => {
+                if challenge_type == ChallengeType::GenreAndDecade {
+                    if config.challenge_param1.is_none() || config.challenge_param2.is_none() {
                         is_valid = false;
-                        error_message = 'Challenge param2 required';
+                        error_message = 'Challenge requires both params';
                     }
                 }
-
-                match config.challenge_param1 {
-                    Option::Some(param1) => {
-                        if *param1 == 0 {
-                            is_valid = false;
-                            error_message = 'Challenge param1 cannot be zero';
-                        }
-                    },
-                    Option::None => {
-                        is_valid = false;
-                        error_message = 'Both challenge params required';
-                    }
-                }
-            }
-
-            if challenge_type == ChallengeType::Random {
+            },
+            Option::None => {
                 if config.challenge_param1.is_some() || config.challenge_param2.is_some() {
                     is_valid = false;
-                    error_message = 'Random challenge has params';
+                    error_message = 'Challenge params without type';
                 }
-            }
-
-            if challenge_type == ChallengeType::GenreAndDecade {
-                if config.challenge_param1.is_none() || config.challenge_param2.is_none() {
-                    is_valid = false;
-                    error_message = 'Challenge requires both params';
-                }
-            }
-
-            
-        },
-        Option::None => {
-            if config.challenge_param1.is_some() || config.challenge_param2.is_some() {
-                is_valid = false;
-                error_message = 'Challenge params without type';
-            }
+            },
         }
-    }
-
 
         RoundValidation { is_valid, error_message }
     }
@@ -239,9 +234,9 @@ mod tests {
     fn test_zero_wager_amount() {
         let mut config = create_base_config();
         config.wager_amount = 0;
-        
+
         let validation = RoundTrait::validate_config(@config);
-        
+
         assert!(!validation.is_valid, "Zero wager amount should be invalid");
         assert_eq!(validation.error_message, 'Wager amount cannot be zero');
     }
@@ -261,9 +256,9 @@ mod tests {
         let mut config = create_base_config();
         config.mode = Mode::Solo;
         config.max_players = 5;
-        
+
         let validation = RoundTrait::validate_config(@config);
-        
+
         assert!(!validation.is_valid, "Solo mode with multiple players should be invalid");
         assert_eq!(validation.error_message, 'Solo mode must have one player');
     }
@@ -272,9 +267,9 @@ mod tests {
     fn test_invalid_max_players() {
         let mut config = create_base_config();
         config.max_players = 0;
-        
+
         let validation = RoundTrait::validate_config(@config);
-        
+
         assert!(!validation.is_valid, "Max players count of 0 should be invalid");
         assert_eq!(validation.error_message, 'Invalid max players count');
     }
@@ -284,9 +279,9 @@ mod tests {
     fn test_max_players_over_limit() {
         let mut config = create_base_config();
         config.max_players = 51;
-        
+
         let validation = RoundTrait::validate_config(@config);
-        
+
         assert!(!validation.is_valid, "Max players over 50 should be invalid");
         assert_eq!(validation.error_message, 'Invalid max players count');
     }
@@ -295,13 +290,13 @@ mod tests {
     fn test_zero_cards_per_round() {
         let mut config = create_base_config();
         config.cards_per_round = 0;
-        
+
         let validation = RoundTrait::validate_config(@config);
-        
+
         assert!(!validation.is_valid, "Zero cards per round should be invalid");
         assert_eq!(validation.error_message, 'Invalid cards per round count');
     }
-    
+
     #[test]
     fn test_cards_per_round_over_limit() {
         let mut config = create_base_config();
@@ -328,9 +323,9 @@ mod tests {
     fn test_random_challenge_without_params() {
         let mut config = create_base_config();
         config.challenge_type = Option::Some(ChallengeType::Random);
-        
+
         let validation = RoundTrait::validate_config(@config);
-        
+
         assert!(validation.is_valid, "Random challenge without params should be valid");
     }
 
@@ -350,9 +345,9 @@ mod tests {
         let mut config = create_base_config();
         config.challenge_type = Option::Some(ChallengeType::Random);
         config.challenge_param2 = Option::Some(1);
-        
+
         let validation = RoundTrait::validate_config(@config);
-        
+
         assert!(!validation.is_valid, "Random challenge with param2 should be invalid");
         assert_eq!(validation.error_message, 'Random challenge has params');
     }
@@ -386,9 +381,9 @@ mod tests {
     fn test_genre_and_decade_challenge_without_params() {
         let mut config = create_base_config();
         config.challenge_type = Option::Some(ChallengeType::GenreAndDecade);
-        
+
         let validation = RoundTrait::validate_config(@config);
-        
+
         assert!(!validation.is_valid, "GenreAndDecade challenge without params should be invalid");
         assert_eq!(validation.error_message, 'Challenge requires both params');
     }
@@ -447,7 +442,6 @@ mod tests {
         let mut config = create_base_config();
         config.challenge_type = Option::Some(ChallengeType::Genre);
 
-
         let validation = RoundTrait::validate_config(@config);
 
         assert!(!validation.is_valid, "Missing challenge_param1 should be invalid");
@@ -490,5 +484,4 @@ mod tests {
         assert!(!validation.is_valid, "Challenge param1 of zero should be invalid");
         assert_eq!(validation.error_message, 'Challenge param1 cannot be zero');
     }
-
 }

--- a/src/models/round/round.cairo
+++ b/src/models/round/round.cairo
@@ -78,6 +78,123 @@ pub impl RoundImpl of RoundTrait {
     fn get_challenge_type(self: @Round) -> ChallengeType {
         (*self.challenge_type).try_into().unwrap()
     }
+
+    fn validate_config(config: @RoundConfig) -> RoundValidation {
+        let mut is_valid = true;
+        let mut error_message: felt252 = 0;
+
+        if *config.wager_amount == 0 {
+            is_valid = false;
+            error_message = 'Wager amount cannot be zero';
+        }
+
+
+        if *config.mode == Mode::Solo{
+            if *config.max_players != 1 {
+                is_valid = false;
+                error_message = 'Solo mode must have one player';
+            }
+        }
+
+        if *config.max_players <= 0 || *config.max_players > 50 {
+            is_valid = false;
+            error_message = 'Invalid max players count';
+        }
+
+        if *config.cards_per_round <= 0 || *config.cards_per_round > 100 {
+            is_valid = false;
+            error_message = 'Invalid cards per round count';
+        }
+
+        if *config.card_timeout <= 0 {
+            is_valid = false;
+            error_message = 'Card timeout cannot be zero';
+        }
+
+        match *config.challenge_type {
+        Option::Some(challenge_type) => {
+            if challenge_type.requires_param() {
+                match config.challenge_param1 {
+                    Option::Some(param1) => {
+                        if *param1 == 0 {
+                            is_valid = false;
+                            error_message = 'Challenge param1 cannot be zero';
+                        }
+                    },
+                    Option::None => {
+                        is_valid = false;
+                        error_message = 'Challenge param1 required';
+                    }
+                }
+
+                match config.challenge_param2 {
+                    Option::Some(param2) => {
+                        if challenge_type != ChallengeType::GenreAndDecade{
+                            is_valid = false;
+                            error_message = 'Challenge param2 not required';
+                        }
+                    },
+                    Option::None => {
+                        // No action needed, param2 is optional
+                    }
+                }
+            }
+
+            if challenge_type.requires_two_params() {
+                match config.challenge_param2 {
+                    Option::Some(param2) => {
+                        if *param2 == 0 {
+                            is_valid = false;
+                            error_message = 'Challenge param2 cannot be zero';
+                        }
+                    },
+                    Option::None => {
+                        is_valid = false;
+                        error_message = 'Challenge param2 required';
+                    }
+                }
+
+                match config.challenge_param1 {
+                    Option::Some(param1) => {
+                        if *param1 == 0 {
+                            is_valid = false;
+                            error_message = 'Challenge param1 cannot be zero';
+                        }
+                    },
+                    Option::None => {
+                        is_valid = false;
+                        error_message = 'Both challenge params required';
+                    }
+                }
+            }
+
+            if challenge_type == ChallengeType::Random {
+                if config.challenge_param1.is_some() || config.challenge_param2.is_some() {
+                    is_valid = false;
+                    error_message = 'Random challenge has params';
+                }
+            }
+
+            if challenge_type == ChallengeType::GenreAndDecade {
+                if config.challenge_param1.is_none() || config.challenge_param2.is_none() {
+                    is_valid = false;
+                    error_message = 'Challenge requires both params';
+                }
+            }
+
+            
+        },
+        Option::None => {
+            if config.challenge_param1.is_some() || config.challenge_param2.is_some() {
+                is_valid = false;
+                error_message = 'Challenge params without type';
+            }
+        }
+    }
+
+
+        RoundValidation { is_valid, error_message }
+    }
 }
 
 #[generate_trait]
@@ -95,4 +212,283 @@ mod tests {
     use super::{RoundTrait, RoundConfigTrait, RoundConfig, RoundImpl};
     use starknet::contract_address_const;
     use lyricsflip::models::game_types::{Mode, ChallengeType, RoundState};
+
+    fn create_base_config() -> RoundConfig {
+        RoundConfig {
+            wager_amount: 100,
+            mode: Mode::MultiPlayer,
+            max_players: 5,
+            cards_per_round: 10,
+            card_timeout: 30,
+            challenge_type: Option::None,
+            challenge_param1: Option::None,
+            challenge_param2: Option::None,
+        }
+    }
+
+    #[test]
+    fn test_valid_config() {
+        let config = create_base_config();
+        let validation = RoundTrait::validate_config(@config);
+
+        assert!(validation.is_valid, "Valid config should pass validation");
+        assert_eq!(validation.error_message, 0, "Valid config should have no error message");
+    }
+
+    #[test]
+    fn test_zero_wager_amount() {
+        let mut config = create_base_config();
+        config.wager_amount = 0;
+        
+        let validation = RoundTrait::validate_config(@config);
+        
+        assert!(!validation.is_valid, "Zero wager amount should be invalid");
+        assert_eq!(validation.error_message, 'Wager amount cannot be zero');
+    }
+
+    #[test]
+    fn test_solo_mode_with_one_player() {
+        let mut config = create_base_config();
+        config.mode = Mode::Solo;
+        config.max_players = 1;
+
+        let validation = RoundTrait::validate_config(@config);
+        assert!(validation.is_valid, "Solo mode with 1 player should be valid");
+    }
+
+    #[test]
+    fn test_solo_mode_with_multiple_players() {
+        let mut config = create_base_config();
+        config.mode = Mode::Solo;
+        config.max_players = 5;
+        
+        let validation = RoundTrait::validate_config(@config);
+        
+        assert!(!validation.is_valid, "Solo mode with multiple players should be invalid");
+        assert_eq!(validation.error_message, 'Solo mode must have one player');
+    }
+
+    #[test]
+    fn test_invalid_max_players() {
+        let mut config = create_base_config();
+        config.max_players = 0;
+        
+        let validation = RoundTrait::validate_config(@config);
+        
+        assert!(!validation.is_valid, "Max players count of 0 should be invalid");
+        assert_eq!(validation.error_message, 'Invalid max players count');
+    }
+
+
+    #[test]
+    fn test_max_players_over_limit() {
+        let mut config = create_base_config();
+        config.max_players = 51;
+        
+        let validation = RoundTrait::validate_config(@config);
+        
+        assert!(!validation.is_valid, "Max players over 50 should be invalid");
+        assert_eq!(validation.error_message, 'Invalid max players count');
+    }
+
+    #[test]
+    fn test_zero_cards_per_round() {
+        let mut config = create_base_config();
+        config.cards_per_round = 0;
+        
+        let validation = RoundTrait::validate_config(@config);
+        
+        assert!(!validation.is_valid, "Zero cards per round should be invalid");
+        assert_eq!(validation.error_message, 'Invalid cards per round count');
+    }
+    
+    #[test]
+    fn test_cards_per_round_over_limit() {
+        let mut config = create_base_config();
+        config.cards_per_round = 101;
+
+        let validation = RoundTrait::validate_config(@config);
+
+        assert!(!validation.is_valid, "Cards per round over 100 should be invalid");
+        assert_eq!(validation.error_message, 'Invalid cards per round count');
+    }
+
+    #[test]
+    fn test_zero_card_timeout() {
+        let mut config = create_base_config();
+        config.card_timeout = 0;
+
+        let validation = RoundTrait::validate_config(@config);
+
+        assert!(!validation.is_valid, "Zero card timeout should be invalid");
+        assert_eq!(validation.error_message, 'Card timeout cannot be zero');
+    }
+
+    #[test]
+    fn test_random_challenge_without_params() {
+        let mut config = create_base_config();
+        config.challenge_type = Option::Some(ChallengeType::Random);
+        
+        let validation = RoundTrait::validate_config(@config);
+        
+        assert!(validation.is_valid, "Random challenge without params should be valid");
+    }
+
+    fn test_random_challenge_with_param1() {
+        let mut config = create_base_config();
+        config.challenge_type = Option::Some(ChallengeType::Random);
+        config.challenge_param1 = Option::Some(1);
+
+        let validation = RoundTrait::validate_config(@config);
+
+        assert!(!validation.is_valid, "Random challenge with param1 should be invalid");
+        assert_eq!(validation.error_message, 'Random challenge has params');
+    }
+
+    #[test]
+    fn test_random_challenge_with_param2() {
+        let mut config = create_base_config();
+        config.challenge_type = Option::Some(ChallengeType::Random);
+        config.challenge_param2 = Option::Some(1);
+        
+        let validation = RoundTrait::validate_config(@config);
+        
+        assert!(!validation.is_valid, "Random challenge with param2 should be invalid");
+        assert_eq!(validation.error_message, 'Random challenge has params');
+    }
+
+    #[test]
+    fn test_random_challenge_with_both_params() {
+        let mut config = create_base_config();
+        config.challenge_type = Option::Some(ChallengeType::Random);
+        config.challenge_param1 = Option::Some(1);
+        config.challenge_param2 = Option::Some(2);
+
+        let validation = RoundTrait::validate_config(@config);
+
+        assert!(!validation.is_valid, "Random challenge with both params should be invalid");
+        assert_eq!(validation.error_message, 'Random challenge has params');
+    }
+
+    #[test]
+    fn test_genre_and_decade_with_both_params() {
+        let mut config = create_base_config();
+        config.challenge_type = Option::Some(ChallengeType::GenreAndDecade);
+        config.challenge_param1 = Option::Some(1);
+        config.challenge_param2 = Option::Some(1980);
+
+        let validation = RoundTrait::validate_config(@config);
+
+        assert!(validation.is_valid, "GenreAndDecade with both params should be valid");
+    }
+
+    #[test]
+    fn test_genre_and_decade_challenge_without_params() {
+        let mut config = create_base_config();
+        config.challenge_type = Option::Some(ChallengeType::GenreAndDecade);
+        
+        let validation = RoundTrait::validate_config(@config);
+        
+        assert!(!validation.is_valid, "GenreAndDecade challenge without params should be invalid");
+        assert_eq!(validation.error_message, 'Challenge requires both params');
+    }
+
+    #[test]
+    fn test_genre_and_decade_missing_param1() {
+        let mut config = create_base_config();
+        config.challenge_type = Option::Some(ChallengeType::GenreAndDecade);
+        config.challenge_param2 = Option::Some(1980);
+
+        let validation = RoundTrait::validate_config(@config);
+
+        assert!(!validation.is_valid, "GenreAndDecade missing param1 should be invalid");
+        assert_eq!(validation.error_message, 'Challenge requires both params');
+    }
+
+    #[test]
+    fn test_genre_and_decade_missing_param2() {
+        let mut config = create_base_config();
+        config.challenge_type = Option::Some(ChallengeType::GenreAndDecade);
+        config.challenge_param1 = Option::Some(1);
+
+        let validation = RoundTrait::validate_config(@config);
+
+        assert!(!validation.is_valid, "GenreAndDecade missing param2 should be invalid");
+        assert_eq!(validation.error_message, 'Challenge requires both params');
+    }
+
+    #[test]
+    fn test_challenge_params_without_type() {
+        let mut config = create_base_config();
+        config.challenge_param1 = Option::Some(1);
+        config.challenge_param2 = Option::Some(2);
+
+        let validation = RoundTrait::validate_config(@config);
+
+        assert!(!validation.is_valid, "Challenge params without type should be invalid");
+        assert_eq!(validation.error_message, 'Challenge params without type');
+    }
+
+    #[test]
+    fn test_challenge_params_with_none_type() {
+        let mut config = create_base_config();
+        config.challenge_type = Option::None;
+        config.challenge_param1 = Option::Some(1);
+        config.challenge_param2 = Option::Some(2);
+
+        let validation = RoundTrait::validate_config(@config);
+
+        assert!(!validation.is_valid, "Challenge params with None type should be invalid");
+        assert_eq!(validation.error_message, 'Challenge params without type');
+    }
+
+    #[test]
+    fn test_required_challenge_param1() {
+        let mut config = create_base_config();
+        config.challenge_type = Option::Some(ChallengeType::Genre);
+
+
+        let validation = RoundTrait::validate_config(@config);
+
+        assert!(!validation.is_valid, "Missing challenge_param1 should be invalid");
+        assert_eq!(validation.error_message, 'Challenge param1 required');
+    }
+
+    #[test]
+    fn test_challenge_with_require_param_has_param_2() {
+        let mut config = create_base_config();
+        config.challenge_type = Option::Some(ChallengeType::Genre);
+        config.challenge_param2 = Option::Some(1);
+
+        let validation = RoundTrait::validate_config(@config);
+
+        assert!(!validation.is_valid, "Missing challenge_param2 should be invalid");
+        assert_eq!(validation.error_message, 'Challenge param2 not required');
+    }
+
+    #[test]
+    fn test_challenge_requiring_two_params_with_zero_param2() {
+        let mut config = create_base_config();
+        config.challenge_type = Option::Some(ChallengeType::GenreAndDecade);
+        config.challenge_param1 = Option::Some(1);
+        config.challenge_param2 = Option::Some(0);
+
+        let validation = RoundTrait::validate_config(@config);
+
+        assert!(!validation.is_valid, "Challenge param2 of zero should be invalid");
+        assert_eq!(validation.error_message, 'Challenge param2 cannot be zero');
+    }
+
+    #[test]
+    fn test_challenge_requiring_param_with_zero_param1() {
+        let mut config = create_base_config();
+        config.challenge_type = Option::Some(ChallengeType::Genre);
+        config.challenge_param1 = Option::Some(0);
+
+        let validation = RoundTrait::validate_config(@config);
+
+        assert!(!validation.is_valid, "Challenge param1 of zero should be invalid");
+        assert_eq!(validation.error_message, 'Challenge param1 cannot be zero');
+    }
+
 }

--- a/src/models/round/round.cairo
+++ b/src/models/round/round.cairo
@@ -133,7 +133,7 @@ pub impl RoundImpl of RoundTrait {
                                 error_message = 'Challenge param2 not required';
                             }
                         },
-                        Option::None => {// No action needed, param2 is optional
+                        Option::None => { // No action needed, param2 is optional
                         },
                     }
                 }

--- a/src/models/round/round.cairo
+++ b/src/models/round/round.cairo
@@ -83,9 +83,11 @@ pub impl RoundImpl of RoundTrait {
         let mut is_valid = true;
         let mut error_message: felt252 = 0;
 
-        if *config.wager_amount == 0 {
-            is_valid = false;
-            error_message = 'Wager amount cannot be zero';
+        if *config.mode == Mode::WagerMultiPlayer {
+            if *config.wager_amount == 0 {
+                is_valid = false;
+                error_message = 'Wager amount cannot be zero';
+            }
         }
 
         if *config.mode == Mode::Solo {
@@ -279,7 +281,7 @@ mod tests {
     fn create_base_config() -> RoundConfig {
         RoundConfig {
             wager_amount: 100,
-            mode: Mode::MultiPlayer,
+            mode: Mode::WagerMultiPlayer,
             max_players: 5,
             cards_per_round: 10,
             card_timeout: 30,
@@ -551,7 +553,7 @@ mod tests {
 
         assert!(!validation.is_valid, "Challenge param1 of zero should be invalid");
         assert_eq!(validation.error_message, 'Challenge param1 cannot be zero');
-        }
+    }
 
     #[test]
     fn test_new_solo_config() {
@@ -753,6 +755,5 @@ mod tests {
         let large_players_config = RoundConfigTrait::new(Mode::MultiPlayer, 5)
             .with_max_players(100);
         assert(large_players_config.max_players == 100, 'wrong_max_players');
-
     }
 }


### PR DESCRIPTION
closes #126

This PR adds comprehensive validation logic for the RoundConfig struct through the new validate_config function, along with a full suite of unit tests to ensure proper configuration rules are enforced.

## Changes Made
- **Implemented `validate_config`** to check for invalid game configuration values:
  - Wager amount cannot be zero.
  - Solo mode must have exactly 1 player.
  - Player count must be between 1 and 50.
  - Cards per round must be between 1 and 100.
  - Card timeout must be greater than zero.
  - Challenge type/parameter validation:
    - Enforces required params based on challenge type.
    - Rejects extra params for challenges that don’t require them.
    - Ensures param values are non-zero when required.
    - Prevents params from being set for `Random` challenges.
    - Enforces both params for `GenreAndDecade` challenges.
-  Created `create_base_config` helper to simplify test setup.
- Added full test coverage for all validation rules.

## Testing
- Added unit tests covering all possible validation cases.
- Verified valid configurations pass and all invalid configurations return the correct error message.
